### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ![](https://travis-ci.org/pmkary/tambourine.svg?branch=master)
 
-Tambourine is a framework for writing musical theory software. My main goal is to have a library capable of computing musical theory so that I can write a Hormonizer Engine on top of it. Because this library still doesn't have a the Hormonizer Engine I call it a music theory framework.
+Tambourine is a framework for writing musical theory software. My main goal is to have a library capable of computing musical theory so that I can write a Harmonizer Engine on top of it. Because this library still doesn't have a the Harmonizer Engine I call it a music theory framework.
 
 # Installing It
 You can simply install Tambourine using npm


### PR DESCRIPTION
Change `Hormonizer` to `Harmonizer`. resolve #1 